### PR TITLE
Fix sleeping and add stop script

### DIFF
--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -58,6 +58,14 @@ eips_debug() {
   fi
 }
 
+init() {
+  /etc/init.d/framework stop
+  initctl stop webreader >/dev/null 2>&1
+  echo powersave >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+  lipc-set-prop com.lab126.powerd preventScreenSaver 1
+}
+
+init
 while true; do
   # Clear the screen only if in debug mode, otherwise clear right before displaying the image
   if [ "$DEBUG_MODE" = true ]; then

--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -70,6 +70,17 @@ while true; do
 
   # 1) Indicate the start of a new loop
   eips_debug "TRMNL Kindle Debug Script"
+
+  eips_debug "Wait for wifi..."
+  # enable wireless if it is currently off
+  if [ 0 -eq `lipc-get-prop com.lab126.cmd wirelessEnable` ]; then
+    eips_debug "WiFi is off, turning it on now"
+    lipc-set-prop com.lab126.cmd wirelessEnable 1
+    #lipc-set-prop com.lab126.wifid enable 1 
+    DISABLE_WIFI=1
+  fi
+  "$DIR/wait-for-wifi.sh" "$WIFI_TEST_IP"
+
   eips_debug "Fetching JSON..."
 
   # 2) Fetch JSON metadata
@@ -168,5 +179,18 @@ while true; do
 
   # Optional: show how long we will sleep (only in debug mode)
   eips_debug "Sleeping for $REFRESH_RATE seconds..."
-  sleep "$REFRESH_RATE"
+  
+  # disable wireless if necessary
+  if [ 1 -eq $DISABLE_WIFI ]; then
+    eips_debug "Disabling WiFi"
+    lipc-set-prop com.lab126.cmd wirelessEnable 0
+    #lipc-set-prop com.lab126.wifid enable 0
+  fi
+  
+  # take a bit of time before going to sleep, so this process can be aborted
+  sleep 10
+
+  echo 0 > /sys/class/rtc/rtc1/wakealarm
+  echo "+180" > /sys/class/rtc/rtc1/wakealarm
+  echo "mem" > /sys/power/state
 done

--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -20,6 +20,7 @@ BASE_URL="https://trmnl.app"
 RSSI="0"
 USER_AGENT="trmnl-display/0.1.1"
 DEBUG_MODE=false  # Set to true to enable debug messages, false to disable
+DIR="$(dirname "$0")"
 
 # Temporary folder to hold downloaded files
 TMP_DIR="/tmp/trmnl-kindle"

--- a/zip_example/menu.json
+++ b/zip_example/menu.json
@@ -8,6 +8,11 @@
           "name": "Start TRMNL",
           "priority": 100,
           "action": "./TRMNL.sh"
+        },
+        {
+          "name": "Stop TRMNL",
+          "priority": 100,
+          "action": "./stop.sh"
         }
       ]
     }

--- a/zip_example/stop.sh
+++ b/zip_example/stop.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+pkill -f TRMNL.sh

--- a/zip_example/wait-for-wifi.sh
+++ b/zip_example/wait-for-wifi.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+test_ip=$1
+
+if [ -z "$test_ip" ]; then
+  echo "No test ip specified"
+  exit 1
+fi
+
+wait_for_wifi() {
+  max_retry=30
+  counter=0
+
+  ping -c 1 "$test_ip" >/dev/null 2>&1
+
+  # shellcheck disable=SC2181
+  while [ $? -ne 0 ]; do
+    [ $counter -eq $max_retry ] && echo "Couldn't connect to Wi-Fi" && exit 1
+    counter=$((counter + 1))
+
+    sleep 1
+    ping -c 1 "$test_ip" >/dev/null 2>&1
+  done
+}
+
+wait_for_wifi
+echo "Wi-Fi connected"


### PR DESCRIPTION
As said in issue https://github.com/usetrmnl/trmnl-kindle/issues/10, my kindle PW3 goes into deep sleep after circa 1min in sleep. Because of this, you have to use something other than just the sleep function.
After some reading on https://github.com/pascalw/kindle-dash and https://www.mobileread.com/forums/showthread.php?t=235821, I wrote a commit to fix it.

It works on my PW3 and should also work on a PW2.
I don't know how sleep is managed on more recent models.

I also included some power management functions that are called in the https://github.com/pascalw/kindle-dash project.