### PR TITLE
feat: implement ID header for curl request for img in example_zip

### DIFF
--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -34,6 +34,9 @@ PNG_WIDTH=$(get_kindle_height)
 PNG_HEIGHT=$(get_kindle_width)
 ROTATION=90
 
+# Get the MAC address for validation
+MAC_ADDRESS=$(get_mac_address)
+
 # ---------------------------------------------------------------------------- #
 
 # If eips is not found (i.e. running locally), define a no-op stub for testing
@@ -81,6 +84,7 @@ while true; do
       -H "png-width: $PNG_WIDTH" \
       -H "png-height: $PNG_HEIGHT" \
       -H "rssi: $RSSI" \
+      -H "ID: $MAC_ADDRESS" \
       -A "$USER_AGENT" \
       "${BASE_URL}/api/display"
   )"

--- a/zip_example/utils.sh
+++ b/zip_example/utils.sh
@@ -1,34 +1,40 @@
 # ----------------------------- UTILITY FUNCTIONS -------------------------------- #
-get_kindle_battery() {                                                                    
-  # Run the command and capture its output                                                
-  local result=$(lipc-get-prop com.lab126.powerd status)                                  
-                                                                                          
-  # Extract the battery level using grep and cut                                          
-  # Find the line with "Battery Level", extract just the percentage number                
+get_kindle_battery() {
+  # Run the command and capture its output
+  local result=$(lipc-get-prop com.lab126.powerd status)
+
+  # Extract the battery level using grep and cut
+  # Find the line with "Battery Level", extract just the percentage number
   local battery_level=$(echo "$result" | grep "Battery Level:" | cut -d ":" -f2 | tr -d '% ')
-                                                                                          
-  # Return just the number                                                                
-  echo "$battery_level"                                                                   
-}                                                                                         
-                                                                                          
-get_kindle_width() {                                                                      
-  # Run the command and capture its output                                                
-  local result=$(eips -i)                                                                 
-                                                                                          
-  # Extract xres using grep and awk                                                       
-  local xres=$(echo "$result" | grep "xres:" | head -1 | awk '{print $2}')                
-                                                                                          
-  # Return just the width value                                                           
-  echo "$xres"                                                                            
-}                                                                                         
-                                                                                          
-get_kindle_height() {                                                                     
-  # Run the command and capture its output                                                
-  local result=$(eips -i)                                                                 
-                                                                                          
-  # Extract yres using grep and awk                                                       
-  local yres=$(echo "$result" | grep "yres:" | head -1 | awk '{print $4}')                
-                                                                                          
-  # Return just the height value                                                          
-  echo "$yres"                                                                            
-}      
+
+  # Return just the number
+  echo "$battery_level"
+}
+
+get_kindle_width() {
+  # Run the command and capture its output
+  local result=$(eips -i)
+
+  # Extract xres using grep and awk
+  local xres=$(echo "$result" | grep "xres:" | head -1 | awk '{print $2}')
+
+  # Return just the width value
+  echo "$xres"
+}
+
+get_kindle_height() {
+  # Run the command and capture its output
+  local result=$(eips -i)
+
+  # Extract yres using grep and awk
+  local yres=$(echo "$result" | grep "yres:" | head -1 | awk '{print $4}')
+
+  # Return just the height value
+  echo "$yres"
+}
+
+get_mac_address() {
+    local address=$(cat /sys/class/net/wlan0/address | tr '[:lower:]' '[:upper:]')
+
+    echo "$address"
+}


### PR DESCRIPTION
I noticed when I was working on BYOS and a Kindle 2019 that the curl request required an `ID` header with the mac address of the Kindle to successfully work.

- Added the `ID` header and a `get_mac_address()` function to `utils.sh`