### PR TITLE
Changes to support Kindle PW

### DIFF
--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -40,7 +40,7 @@ MAC_ADDRESS=$(get_mac_address)
 # ---------------------------------------------------------------------------- #
 
 # If eips is not found (i.e. running locally), define a no-op stub for testing
-if ! command -v eips >/dev/null 2>&1; then
+if ! which eips >/dev/null 2>&1; then
   eips() {
     # Simply echo to console so you can see what *would* happen on Kindle
     echo "[eips STUB] $*"

--- a/zip_example/utils.sh
+++ b/zip_example/utils.sh
@@ -34,7 +34,7 @@ get_kindle_height() {
 }
 
 get_mac_address() {
-    local address=$(cat /sys/class/net/wlan0/address | tr '[:lower:]' '[:upper:]')
+  local address=$(cat /sys/class/net/wlan0/address | tr a-z A-Z)
 
-    echo "$address"
+  echo "$address"
 }


### PR DESCRIPTION
I have an old PW1 and it runs an old busybox and I had to adjust the scripts to make it work.

Mainly, `command` is not available and `tr` doesn't accept `[:lower:]/[:upper:]` format.