### PR TITLE
Add an option to override default configuration variables in a separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 zip_example/apikey.txt
+zip_example/TRMNL_config.sh
 .idea

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Create a new file called `apikey.txt` in the `TRMNL_KINDLE` directory that only 
 
 <kdb><img src="https://github.com/usetrmnl/trmnl-kindle/blob/main/images/trmnl-kindle-extension.png" width="500px"></kdb>
 
+Alternatively, you can copy the `TRMNL_config.sh.example` file as `TRMNL_config.sh` and edit the `API_KEY` 
+variable. The `TRMNL_config.sh` is not tracked by the repository, making it convenient for local experimentation
+and development.
+
 ### 25. Disconnect Kindle
 Safely eject (disconnect) your Kindle.
 

--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -16,7 +16,7 @@ source ./utils.sh
 #
 # ----------------------------- USER SETTINGS -------------------------------- #
 
-if [ -e apikey.sh ]; then
+if [ -e apikey.txt ]; then
   API_KEY=$(cat apikey.txt)
 fi
 

--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -15,7 +15,11 @@ source ./utils.sh
 ###############################################################################
 #
 # ----------------------------- USER SETTINGS -------------------------------- #
-API_KEY=$(cat apikey.txt)
+
+if [ -e apikey.sh ]; then
+  API_KEY=$(cat apikey.txt)
+fi
+
 BASE_URL="https://trmnl.app"
 RSSI="0"
 USER_AGENT="trmnl-display/0.1.1"
@@ -37,6 +41,10 @@ MIN_REFRESH_RATE=300
 
 # Get the MAC address for validation
 MAC_ADDRESS=$(get_mac_address)
+
+if [ -e ./TRMNL_config.sh ]; then
+  source ./TRMNL_config.sh
+fi
 
 # ---------------------------------------------------------------------------- #
 

--- a/zip_example/TRMNL_config.sh.example
+++ b/zip_example/TRMNL_config.sh.example
@@ -1,0 +1,24 @@
+# This is an example of the config file, that overrides default values
+# for the main script.
+#
+# Copy it as `TRMNL_config.sh` and edit with desired values
+
+# API key of your device
+API_KEY="YOUR_UNIQUE_API_KEY"
+
+# BASE URL of the TRMNL server
+BASE_URL="https://trmnl.app"
+
+# Size of the PNG in *pixels*
+PNG_WIDTH=$(get_kindle_height)
+PNG_HEIGHT=$(get_kindle_width)
+
+# Minimal time to sleep for between refreshes. Takes priority over the server
+# provided refresh rate.
+MIN_REFRESH_RATE=300
+
+# Get the MAC address for validation
+MAC_ADDRESS=$(get_mac_address)
+
+# Set to true to enable debug messages, false to disable
+DEBUG_MODE=true


### PR DESCRIPTION
Adds support for the `TRMNL_config.sh` file, which can be loaded by the main script to override the default values of the environmental variables. This allows for making local changes without affecting the files tracked by the repository which is especially useful for developers.

For example - I use the BYOS setup and do not want to manually flip the server address back to the default when commiting changes.

Keeping backwards compatibility with current `apikey.txt`.