### PR TITLE
Add support for Kindle 4

### DIFF
--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -67,6 +67,7 @@ if ! command -v eips >/dev/null 2>&1 \
     # Simply echo to console so you can see what *would* happen on Kindle
     echo "[eips STUB] $*"
   }
+  echo "eips binary not found! Screen changes won't be applied." >&2
 fi
 
 # Helper to track a text-based "cursor" for debug lines
@@ -82,18 +83,6 @@ eips_debug() {
     DEBUG_Y=$((DEBUG_Y+1))
   fi
 }
-
-# If eips is not found (i.e. running locally), define a no-op stub for testing
-if ! command -v eips >/dev/null 2>&1 \
- && ! type eips >/dev/null 2>&1 \
- && ! [ -x /usr/sbin/eips ]; then
-  eips() {
-    # Simply echo to console so you can see what *would* happen on Kindle
-    echo "[eips STUB] $*"
-  }
-  eips_debug "eips binary not found! Screen changes won't be applied."
-fi
-
 
 init() {
   /etc/init.d/framework stop
@@ -151,7 +140,7 @@ while true; do
   RESPONSE="$(
     curl -sL \
       -H "access-token: $API_KEY" \
-      -H "battery-percent: ${BATTERY_PERCENT}" \
+      -H "percent-charged: ${BATTERY_PERCENT}" \
       -H "png-width: $PNG_WIDTH" \
       -H "png-height: $PNG_HEIGHT" \
       -H "rssi: $RSSI" \

--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -46,6 +46,17 @@ if [ -e ./TRMNL_config.sh ]; then
   source ./TRMNL_config.sh
 fi
 
+# IP or domain used to test if network is up (without the protocol, port or
+# path)
+WIFI_TEST_ADDRESS=$(echo "$BASE_URL" | cut -d/ -f3 | cut -d: -f1)
+
+# How wifi power state should be managed:
+# * ${WIFI_ALWAYS_ON} - keep wifi on
+# * ${WIFI_DISABLED_DURING_SLEEP} - disable wifi before going to sleep
+# * ${WIFI_AUTO} - keep wifi state during sleep as it was before script 
+#   execution
+WIFI_MANAGEMENT=${WIFI_DISABLED_DURING_SLEEP}
+
 # ---------------------------------------------------------------------------- #
 
 # If eips is not found (i.e. running locally), define a no-op stub for testing
@@ -72,14 +83,44 @@ eips_debug() {
   fi
 }
 
+# If eips is not found (i.e. running locally), define a no-op stub for testing
+if ! command -v eips >/dev/null 2>&1 \
+ && ! type eips >/dev/null 2>&1 \
+ && ! [ -x /usr/sbin/eips ]; then
+  eips() {
+    # Simply echo to console so you can see what *would* happen on Kindle
+    echo "[eips STUB] $*"
+  }
+  eips_debug "eips binary not found! Screen changes won't be applied."
+fi
+
+
 init() {
   /etc/init.d/framework stop
   initctl stop webreader >/dev/null 2>&1
   echo powersave >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
   lipc-set-prop com.lab126.powerd preventScreenSaver 1
+  
+  # Note: The main body tries to keep the intial WiFi state during the sleep
+  # period, so we set it to the intent. Alternatively, we could drive this via
+  # the initial value of `DISABLE_WIFI`, but this feels too implicit and error
+  # prone.
+  if [ ${WIFI_MANAGEMENT} -eq ${WIFI_ALWAYS_ON} ]; then
+    eips_debug "WiFi set to always ON"
+    INITIAL_WIFI_STATE=1
+  elif [ ${WIFI_MANAGEMENT} -eq ${WIFI_DISABLED_DURING_SLEEP} ]; then
+    eips_debug "WiFi set to be disabled during sleep"
+    INITIAL_WIFI_STATE=0
+  else
+    eips_debug "WiFi will keep initial state during sleep"
+    INITIAL_WIFI_STATE=$(lipc-get-prop com.lab126.cmd wirelessEnable)
+  fi
+  eips_debug "Setting intitial WiFi state to: ${INITIAL_WIFI_STATE}"
+  lipc-set-prop com.lab126.cmd wirelessEnable ${INITIAL_WIFI_STATE}
 }
 
 init
+DISABLE_WIFI=0
 while true; do
   # Clear the screen only if in debug mode, otherwise clear right before displaying the image
   if [ "$DEBUG_MODE" = true ]; then
@@ -101,16 +142,16 @@ while true; do
     #lipc-set-prop com.lab126.wifid enable 1 
     DISABLE_WIFI=1
   fi
-  "$DIR/wait-for-wifi.sh" "$WIFI_TEST_IP"
+  "$DIR/wait-for-wifi.sh" "$WIFI_TEST_ADDRESS"
 
   eips_debug "Fetching JSON..."
 
   # 2) Fetch JSON metadata
-  BATTERY_VOLTAGE=$(get_kindle_battery)
+  BATTERY_PERCENT=$(get_kindle_battery)
   RESPONSE="$(
     curl -sL \
       -H "access-token: $API_KEY" \
-      -H "battery-voltage: $BATTERY_VOLTAGE" \
+      -H "battery-percent: ${BATTERY_PERCENT}" \
       -H "png-width: $PNG_WIDTH" \
       -H "png-height: $PNG_HEIGHT" \
       -H "rssi: $RSSI" \
@@ -195,7 +236,15 @@ while true; do
   # Always clear screen before showing the image
   eips -c
   sleep 1
-  eips -g "$IMAGE_PATH" -x "$DISPLAY_X" -y "$DISPLAY_Y"
+  # eips on particular old Kindles (e.g. Kindle 4) does not support -x -y for
+  # image display (-g). Try to naively detect this by checking for -y existence
+  # in the usage strings
+  if eips | grep -q -v "\-y" ; then
+    eips_debug "Using compatiblity mode for image plotting"
+    eips -g "$IMAGE_PATH"
+  else
+    eips -g "$IMAGE_PATH" -x "$DISPLAY_X" -y "$DISPLAY_Y"
+  fi
 
   # 6) Print full URL & filename below the displayed image only if debug mode is on
   if [ "$DEBUG_MODE" = true ]; then
@@ -205,17 +254,18 @@ while true; do
 
   # Optional: show how long we will sleep (only in debug mode)
   eips_debug "Sleeping for $REFRESH_RATE seconds..."
-  
   # disable wireless if necessary
   if [ 1 -eq $DISABLE_WIFI ]; then
     eips_debug "Disabling WiFi"
     lipc-set-prop com.lab126.cmd wirelessEnable 0
     #lipc-set-prop com.lab126.wifid enable 0
   fi
-  
-  # take a bit of time before going to sleep, so this process can be aborted
-  sleep 10
 
+  # Take a bit of time before going to sleep, so this process can be aborted.
+  # This also prevents the hardware sleep mode from interrupting the screen
+  # refresh when plotting the image.
+  sleep 10
+  
   echo 0 > /sys/class/rtc/rtc1/wakealarm
   echo "+${REFRESH_RATE}" > /sys/class/rtc/rtc1/wakealarm
   echo "mem" > /sys/power/state

--- a/zip_example/TRMNL.sh
+++ b/zip_example/TRMNL.sh
@@ -42,20 +42,20 @@ MIN_REFRESH_RATE=300
 # Get the MAC address for validation
 MAC_ADDRESS=$(get_mac_address)
 
+# How wifi power state should be managed:
+# * ${WIFI_ALWAYS_ON} - keep wifi on
+# * ${WIFI_DISABLED_DURING_SLEEP} - disable wifi before going to sleep
+# * ${WIFI_AUTO} - keep wifi state during sleep as it was before script
+#   execution
+WIFI_MANAGEMENT=${WIFI_DISABLED_DURING_SLEEP}
+
 if [ -e ./TRMNL_config.sh ]; then
   source ./TRMNL_config.sh
 fi
 
 # IP or domain used to test if network is up (without the protocol, port or
 # path)
-WIFI_TEST_ADDRESS=$(echo "$BASE_URL" | cut -d/ -f3 | cut -d: -f1)
-
-# How wifi power state should be managed:
-# * ${WIFI_ALWAYS_ON} - keep wifi on
-# * ${WIFI_DISABLED_DURING_SLEEP} - disable wifi before going to sleep
-# * ${WIFI_AUTO} - keep wifi state during sleep as it was before script 
-#   execution
-WIFI_MANAGEMENT=${WIFI_DISABLED_DURING_SLEEP}
+WIFI_TEST_ADDRESS=${WIFI_TEST_ADDRESS:-$(echo "$BASE_URL" | cut -d/ -f3 | cut -d: -f1)}
 
 # ---------------------------------------------------------------------------- #
 

--- a/zip_example/TRMNL_config.sh.example
+++ b/zip_example/TRMNL_config.sh.example
@@ -20,5 +20,16 @@
 # Get the MAC address for validation
 # MAC_ADDRESS=$(get_mac_address)
 
+# IP or domain used to test if network is up (without the protocol, port or
+# path)
+# WIFI_TEST_ADDRESS=$(echo "$BASE_URL" | cut -d/ -f3 | cut -d: -f1)
+
+# How wifi power state should be managed:
+# * ${WIFI_ALWAYS_ON} - keep wifi on
+# * ${WIFI_DISABLED_DURING_SLEEP} - disable wifi before going to sleep
+# * ${WIFI_AUTO} - keep wifi state during sleep as it was before script 
+#   execution
+# WIFI_MANAGEMENT=${WIFI_DISABLED_DURING_SLEEP}
+
 # Set to true to enable debug messages, false to disable
 # DEBUG_MODE=true

--- a/zip_example/TRMNL_config.sh.example
+++ b/zip_example/TRMNL_config.sh.example
@@ -20,9 +20,8 @@
 # Get the MAC address for validation
 # MAC_ADDRESS=$(get_mac_address)
 
-# IP or domain used to test if network is up (without the protocol, port or
-# path)
-# WIFI_TEST_ADDRESS=$(echo "$BASE_URL" | cut -d/ -f3 | cut -d: -f1)
+# IP or domain used to test if network is up (without the protocol, port or path)
+# WIFI_TEST_ADDRESS="8.8.8.8"
 
 # How wifi power state should be managed:
 # * ${WIFI_ALWAYS_ON} - keep wifi on

--- a/zip_example/utils.sh
+++ b/zip_example/utils.sh
@@ -1,3 +1,10 @@
+# ----------------------------- CONSTANTS ---------------------------------------- #
+
+# Constants for configuring the wifi management
+readonly WIFI_AUTO=0
+readonly WIFI_ALWAYS_ON=1
+readonly WIFI_DISABLED_DURING_SLEEP=2
+
 # ----------------------------- UTILITY FUNCTIONS -------------------------------- #
 get_kindle_battery() {
   # Run the command and capture its output


### PR DESCRIPTION
Adds support for Kindle 4, fixing and improving some things along the way.

1) Moved `eips_debug` earlier so that it can be used in all places.

2) Improved `eips` binary detection, as it was suggested on the PR#29 with PW support.

3) Fixed the battery percentage reporting. It was using the `battery-voltage` header which expects voltage in volts and converts to percentage server side. Now it is passed as `battery-percent`.

4) Fixed the `WIFI_TEST_IP` which was never initialized, making the wifi test always fail.

5) Added logic around the WiFi power state management. Now, it is possible to explicitly force the WiFi power down during sleep instead of relying on the initial network state. This was super useful to me, as the airplane mode on `Kindle 4` seems to do more than just disabling the network and the `lipc-set-prop com.lab126.cmd wirelessEnable 1` was not bringing it up properly. So now, I boot up Kindle with WiFi enabled and then the script is able to power it off.

6) `eips` on Kindle 4 does not support the `-x OFFSET_X -y OFFSET_Y` flags. Added simple heuristic to detect this case.

7) Added small comment next to the final sleep clarifying that it is actually needed for the image redraw to finish before entering the deep sleep.

Tested on Kindle 4 + local LaraPaper instance.